### PR TITLE
More thorough cleaning of Survey Tally.

### DIFF
--- a/poll/poll.py
+++ b/poll/poll.py
@@ -660,6 +660,10 @@ class SurveyBlock(PollBase):
                     if existing_key not in default_answers:
                         del new_answers[existing_key]
                 self.tally[key] = new_answers
+        # Keys for questions that no longer exist can break calculations.
+        for key in self.tally.keys():
+            if key not in questions:
+                del self.tally[key]
 
     def remove_vote(self):
         """


### PR DESCRIPTION
Tally cleaning did not prune keys in the tally which were no longer in the questions list, which could cause a problem when calculating the total number of votes if a stale key was the first to be iterated over when calculating tally details, since it uses the first key it finds to calculate the total number of votes cast, which should be sane for any active question.
